### PR TITLE
chore(deps): update noodles and noodles-util requirements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # The crates noodles and noodles-util are peer dependencies.  We need to
+      # update them separately, cf. https://github.com/zaeleus/noodles/issues/159.
+      - dependency-name: noodles
+      - dependency-name: noodles-util

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ flate2 = "1.0.25"
 hgvs = "0.5.0"
 lazy_static = "1.4.0"
 log = "0.4.17"
-noodles = { version = "0.33.0", features = ["vcf", "bcf", "csi", "fasta", "bgzf", "tabix"] }
-noodles-util = { version = "0.5.0", features = ["noodles-bcf", "noodles-bgzf", "noodles-vcf", "variant"] }
+noodles = { version = "0.34.0", features = ["vcf", "bcf", "csi", "fasta", "bgzf", "tabix"] }
+noodles-util = { version = "0.6.0", features = ["noodles-bcf", "noodles-bgzf", "noodles-vcf", "variant"] }
 procfs = "0.15.1"
 rocksdb = "0.20.1"
 seqrepo = "0.3.0"


### PR DESCRIPTION
Also, ignoring them in dependabot.yml because they are peer depenencies and dependabot does not handle this well (yet).