### PR TITLE
fix: Allow '.' genotypes

### DIFF
--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -711,13 +711,10 @@ impl VarFishSeqvarTsvWriter {
                 ..Default::default()
             };
 
-            if let Some(gt) = sample
-                .get(&GENOTYPE)
-                .map(|value| match value {
-                    Some(sample::Value::String(s)) => s.to_owned(),
-                    _ => ".".into()
-                })
-            {
+            if let Some(gt) = sample.get(&GENOTYPE).map(|value| match value {
+                Some(sample::Value::String(s)) => s.to_owned(),
+                _ => ".".into(),
+            }) {
                 let individual = self
                     .pedigree
                     .as_ref()
@@ -1683,9 +1680,7 @@ mod test {
         let args = Args {
             genome_release: None,
             path_db: String::from("tests/data/annotate/db"),
-            path_input_vcf: String::from(
-                "tests/data/db/create/badly_formed_vcf_entry.vcf",
-            ),
+            path_input_vcf: String::from("tests/data/db/create/badly_formed_vcf_entry.vcf"),
             output: PathOutput {
                 path_output_vcf: None,
                 path_output_tsv: Some(path_out.into_os_string().into_string().unwrap()),

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -714,10 +714,9 @@ impl VarFishSeqvarTsvWriter {
             if let Some(gt) = sample
                 .get(&GENOTYPE)
                 .map(|value| match value {
-                    Some(sample::Value::String(s)) => Ok(s.to_owned()),
-                    _ => anyhow::bail!("invalid GT value"),
+                    Some(sample::Value::String(s)) => s.to_owned(),
+                    _ => ".".into()
                 })
-                .transpose()?
             {
                 let individual = self
                     .pedigree

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1672,7 +1672,7 @@ mod test {
     #[test]
     fn test_badly_formed_vcf_entry() -> Result<(), anyhow::Error> {
         let temp = TempDir::default();
-        let path_out = temp.join("output.tsv.gz");
+        let path_out = temp.join("output.tsv");
 
         let args_common = crate::common::Args {
             verbose: Verbosity::new(0, 1),
@@ -1693,11 +1693,9 @@ mod test {
 
         run(&args_common, &args)?;
 
-        // let actual = std::fs::read_to_string(args.output.path_output_vcf.unwrap())?;
-        // let expected = std::fs::read_to_string(
-        //     "tests/data/db/create/seqvar_freqs/db-rs1263393206/output.vcf",
-        // )?;
-        // assert_eq!(&expected, &actual);
+        let actual = std::fs::read_to_string(args.output.path_output_tsv.unwrap())?;
+        let expected = std::fs::read_to_string("tests/data/db/create/badly_formed_vcf_entry.tsv")?;
+        assert_eq!(&expected, &actual);
 
         Ok(())
     }

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1672,4 +1672,39 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn test_badly_formed_vcf_entry() -> Result<(), anyhow::Error> {
+        let temp = TempDir::default();
+        let path_out = temp.join("output.tsv.gz");
+
+        let args_common = crate::common::Args {
+            verbose: Verbosity::new(0, 1),
+        };
+        let args = Args {
+            genome_release: None,
+            path_db: String::from("tests/data/annotate/db"),
+            path_input_vcf: String::from(
+                "tests/data/db/create/badly_formed_vcf_entry.vcf",
+            ),
+            output: PathOutput {
+                path_output_vcf: None,
+                path_output_tsv: Some(path_out.into_os_string().into_string().unwrap()),
+            },
+            max_var_count: None,
+            path_input_ped: Some(String::from(
+                "tests/data/db/create/badly_formed_vcf_entry.ped",
+            )),
+        };
+
+        run(&args_common, &args)?;
+
+        // let actual = std::fs::read_to_string(args.output.path_output_vcf.unwrap())?;
+        // let expected = std::fs::read_to_string(
+        //     "tests/data/db/create/seqvar_freqs/db-rs1263393206/output.vcf",
+        // )?;
+        // assert_eq!(&expected, &actual);
+
+        Ok(())
+    }
 }

--- a/tests/data/annotate/vars/badly_formed_vcf_entry.vcf
+++ b/tests/data/annotate/vars/badly_formed_vcf_entry.vcf
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf0554626056c285623cbbd3c3d374a77144e631d793d0adc21f216682c9e46f
-size 9744

--- a/tests/data/annotate/vars/badly_formed_vcf_entry.vcf
+++ b/tests/data/annotate/vars/badly_formed_vcf_entry.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cf0554626056c285623cbbd3c3d374a77144e631d793d0adc21f216682c9e46f
+size 9744

--- a/tests/data/db/create/badly_formed_vcf_entry.ped
+++ b/tests/data/db/create/badly_formed_vcf_entry.ped
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6a175f650923802a94c81637b8cfec56d0f0147a2c7c3a687dd01820a1d7eba
+size 80

--- a/tests/data/db/create/badly_formed_vcf_entry.tsv
+++ b/tests/data/db/create/badly_formed_vcf_entry.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d74185c825c1038bef0ba5ebd5dd2d14d10b3fbafedcd1dcaa8e6224c3ff907
+size 1156

--- a/tests/data/db/create/badly_formed_vcf_entry.vcf
+++ b/tests/data/db/create/badly_formed_vcf_entry.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57e5e636202d9adf6a57088044aa182e53385698f69ac7c678081626713bbe54
+size 9738


### PR DESCRIPTION
This currently only contains a test with the offending vcf line. This will close #177 