### PR TITLE
fix: Make mitochondrial DRAGEN calls not fail mehari

### DIFF
--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -812,7 +812,12 @@ impl VarFishSeqvarTsvWriter {
                     None => Ok(-1),
                     // cf. https://github.com/zaeleus/noodles/issues/164
                     // _ => anyhow::bail!(format!("invalid GQ value {:?} in {:#?}", value, sample)),
-                    _ => anyhow::bail!(format!("invalid GQ value {:?} at {:?}:{:?}", value, record.chromosome(), record.position())),
+                    _ => anyhow::bail!(format!(
+                        "invalid GQ value {:?} at {:?}:{:?}",
+                        value,
+                        record.chromosome(),
+                        record.position()
+                    )),
                 })
                 .transpose()?
             {
@@ -823,13 +828,20 @@ impl VarFishSeqvarTsvWriter {
                 .get(&key::Key::from_str("SQ")?)
                 .map(|value| match value {
                     Some(sample::Value::Float(f)) => Ok(*f),
-                    Some(sample::Value::Array(sample::value::Array::Float(f))) => Ok(f[0].expect("SQ should be a single float value")),
+                    Some(sample::Value::Array(sample::value::Array::Float(f))) => {
+                        Ok(f[0].expect("SQ should be a single float value"))
+                    }
                     None => Ok(-1.0),
                     // cf. https://github.com/zaeleus/noodles/issues/164
                     // _ => anyhow::bail!(format!("invalid GQ value {:?} in {:#?}", value, sample)),
                     // _ => anyhow::bail!(format!("invalid GQ value {:?}", value)),
                     _ => {
-                        anyhow::bail!(format!("invalid SQ value {:?} at {:?}:{:?}", value, record.chromosome(), record.position()))
+                        anyhow::bail!(format!(
+                            "invalid SQ value {:?} at {:?}:{:?}",
+                            value,
+                            record.chromosome(),
+                            record.position()
+                        ))
                     }
                 })
                 .transpose()?

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -823,6 +823,7 @@ impl VarFishSeqvarTsvWriter {
                 .get(&key::Key::from_str("SQ")?)
                 .map(|value| match value {
                     Some(sample::Value::Float(f)) => Ok(*f),
+                    Some(sample::Value::Array(sample::value::Array::Float(f))) => Ok(f[0].expect("SQ should be a single float value")),
                     None => Ok(-1.0),
                     // cf. https://github.com/zaeleus/noodles/issues/164
                     // _ => anyhow::bail!(format!("invalid GQ value {:?} in {:#?}", value, sample)),

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -812,7 +812,7 @@ impl VarFishSeqvarTsvWriter {
                     None => Ok(-1),
                     // cf. https://github.com/zaeleus/noodles/issues/164
                     // _ => anyhow::bail!(format!("invalid GQ value {:?} in {:#?}", value, sample)),
-                    _ => anyhow::bail!(format!("invalid GQ value {:?}", value)),
+                    _ => anyhow::bail!(format!("invalid GQ value {:?} at {:?}:{:?}", value, record.chromosome(), record.position())),
                 })
                 .transpose()?
             {
@@ -827,7 +827,10 @@ impl VarFishSeqvarTsvWriter {
                     None => Ok(-1.0),
                     // cf. https://github.com/zaeleus/noodles/issues/164
                     // _ => anyhow::bail!(format!("invalid GQ value {:?} in {:#?}", value, sample)),
-                    _ => anyhow::bail!(format!("invalid GQ value {:?}", value)),
+                    // _ => anyhow::bail!(format!("invalid GQ value {:?}", value)),
+                    _ => {
+                        anyhow::bail!(format!("invalid SQ value {:?} at {:?}:{:?}", value, record.chromosome(), record.position()))
+                    }
                 })
                 .transpose()?
             {
@@ -1730,7 +1733,7 @@ mod test {
         run(&args_common, &args)?;
 
         let actual = std::fs::read_to_string(args.output.path_output_tsv.unwrap())?;
-        let expected = std::fs::read_to_string("tests/data/db/create/badly_formed_vcf_entry.tsv")?;
+        let expected = std::fs::read_to_string("tests/data/db/create/mitochondrial_variants.tsv")?;
         assert_eq!(&expected, &actual);
 
         Ok(())

--- a/src/annotate/seqvars/mod.rs
+++ b/src/annotate/seqvars/mod.rs
@@ -1699,4 +1699,39 @@ mod test {
 
         Ok(())
     }
+
+    /// Mitochondnrial variants called by the DRAGEN v310 germline caller have special format
+    /// considerations.
+    ///
+    /// See: https://support-docs.illumina.com/SW/DRAGEN_v310/Content/SW/DRAGEN/MitochondrialCalling.htm
+    #[test]
+    fn test_dragen_mitochondrial_variant() -> Result<(), anyhow::Error> {
+        let temp = TempDir::default();
+        let path_out = temp.join("output.tsv");
+
+        let args_common = crate::common::Args {
+            verbose: Verbosity::new(0, 1),
+        };
+        let args = Args {
+            genome_release: None,
+            path_db: String::from("tests/data/annotate/db"),
+            path_input_vcf: String::from("tests/data/db/create/mitochondrial_variants.vcf"),
+            output: PathOutput {
+                path_output_vcf: None,
+                path_output_tsv: Some(path_out.into_os_string().into_string().unwrap()),
+            },
+            max_var_count: None,
+            path_input_ped: Some(String::from(
+                "tests/data/db/create/mitochondrial_variants.ped",
+            )),
+        };
+
+        run(&args_common, &args)?;
+
+        let actual = std::fs::read_to_string(args.output.path_output_tsv.unwrap())?;
+        let expected = std::fs::read_to_string("tests/data/db/create/badly_formed_vcf_entry.tsv")?;
+        assert_eq!(&expected, &actual);
+
+        Ok(())
+    }
 }

--- a/tests/data/db/create/mitochondrial_variants.ped
+++ b/tests/data/db/create/mitochondrial_variants.ped
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6a175f650923802a94c81637b8cfec56d0f0147a2c7c3a687dd01820a1d7eba
+size 80

--- a/tests/data/db/create/mitochondrial_variants.tsv
+++ b/tests/data/db/create/mitochondrial_variants.tsv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e6cdf931d8d0787d3a9a75db79f7e90eb8d85b51bcbbd95e1a5415205dbc9ae
+size 1145

--- a/tests/data/db/create/mitochondrial_variants.vcf
+++ b/tests/data/db/create/mitochondrial_variants.vcf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0758e03e92a8a11b2853a2c51d618a0b63215e6a7c91fd9ca0b56d7236431b3
+size 9601


### PR DESCRIPTION
Currently DRAGEN v310 uses a caller generating something more similar to somatic variant calls.

Closes #187