### PR TITLE
feat: introduce compression-level option for `mehari db create`

### DIFF
--- a/src/db/merge.rs
+++ b/src/db/merge.rs
@@ -17,6 +17,10 @@ pub struct Args {
     /// Output file to write the merged transcript database to.
     #[clap(long)]
     pub output: String,
+
+    /// ZSTD compression level to use.
+    #[arg(long, default_value = "19")]
+    compression_level: i32,
 }
 
 pub fn merge_transcript_databases(
@@ -118,7 +122,7 @@ pub fn run(_common_args: &common::Args, args: &Args) -> Result<(), anyhow::Error
     tracing::info!("Merging transcript databases");
     let tx_db = merge_transcript_databases(tx_dbs)?;
     tracing::info!("Writing merged transcript database");
-    write_tx_db(tx_db, &args.output)?;
+    write_tx_db(tx_db, &args.output, args.compression_level)?;
     tracing::info!("Done loading, merging and writing transcript databases");
     Ok(())
 }


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a --compression-level CLI option to control ZSTD compression level for .zst outputs (default: 19).
  * .zst outputs now honor the specified compression level; non-.zst outputs are written uncompressed.

* **Refactor**
  * Simplified output handling: removed gzip (.gz) output support to standardize on ZSTD or raw output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->