### PR TITLE
fix: pick mode first and length picking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1072,18 +1072,18 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1665,7 +1665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2345,7 +2345,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2444,20 +2444,20 @@ dependencies = [
 
 [[package]]
 name = "kinded"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4bdbb2f423660b19f0e9f7115182214732d8dd5f840cd0a3aee3e22562f34c"
+checksum = "53c48b3aa70f02a317f180f7d4e0834bbd2ffa293e352a132bb2ac9351736635"
 dependencies = [
  "kinded_macros",
 ]
 
 [[package]]
 name = "kinded_macros"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13b4ddc5dcb32f45dac3d6f606da2a52fdb9964a18427e63cd5ef6c0d13288d"
+checksum = "feeb717349480c3d8125f84afdd78e9d7128004d8e2a561c35b3bbd76363d085"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case 0.11.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -3424,18 +3424,18 @@ dependencies = [
 
 [[package]]
 name = "nutype"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70587a780088c67dad31bf722b875c5616096b4d8c0ded8b7de03294ffb9bbb5"
+checksum = "e3ae01f500e59a27e8c868297e15e268105d30ae06dee1ca194e025be29dee2a"
 dependencies = [
  "nutype_macros",
 ]
 
 [[package]]
 name = "nutype_macros"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148934b975faeddd8f0679d7cf11280b50c4c5495d6fe72bdaf07c932874b404"
+checksum = "48a6a6ddc63e6d0cd6b77af9aabae24601b39ad543d29bff88c4761c1fc34700"
 dependencies = [
  "cfg-if",
  "kinded",
@@ -4384,7 +4384,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4940,7 +4940,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5713,7 +5713,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/mehari-python/Cargo.lock
+++ b/mehari-python/Cargo.lock
@@ -1019,9 +1019,9 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -2118,18 +2118,18 @@ dependencies = [
 
 [[package]]
 name = "kinded"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce4bdbb2f423660b19f0e9f7115182214732d8dd5f840cd0a3aee3e22562f34c"
+checksum = "53c48b3aa70f02a317f180f7d4e0834bbd2ffa293e352a132bb2ac9351736635"
 dependencies = [
  "kinded_macros",
 ]
 
 [[package]]
 name = "kinded_macros"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13b4ddc5dcb32f45dac3d6f606da2a52fdb9964a18427e63cd5ef6c0d13288d"
+checksum = "feeb717349480c3d8125f84afdd78e9d7128004d8e2a561c35b3bbd76363d085"
 dependencies = [
  "convert_case",
  "proc-macro2 1.0.106",
@@ -3038,18 +3038,18 @@ dependencies = [
 
 [[package]]
 name = "nutype"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70587a780088c67dad31bf722b875c5616096b4d8c0ded8b7de03294ffb9bbb5"
+checksum = "e3ae01f500e59a27e8c868297e15e268105d30ae06dee1ca194e025be29dee2a"
 dependencies = [
  "nutype_macros",
 ]
 
 [[package]]
 name = "nutype_macros"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "148934b975faeddd8f0679d7cf11280b50c4c5495d6fe72bdaf07c932874b404"
+checksum = "48a6a6ddc63e6d0cd6b77af9aabae24601b39ad543d29bff88c4761c1fc34700"
 dependencies = [
  "cfg-if",
  "kinded",

--- a/mehari/src/annotate/cli.rs
+++ b/mehari/src/annotate/cli.rs
@@ -70,6 +70,10 @@ pub struct TranscriptSettings {
     ///
     /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
     /// either the first one is kept or all are kept.
+    ///
+    /// Transcripts are evaluated in the order these options are provided.
+    /// To prevent variants from being completely dropped, if none of the overlapping
+    /// transcripts match the requested criteria, the longest transcript is the implicit fallback.
     #[arg(long)]
     pub pick_transcript: Vec<TranscriptPickType>,
 

--- a/mehari/src/annotate/seqvars/csq.rs
+++ b/mehari/src/annotate/seqvars/csq.rs
@@ -3,7 +3,7 @@ use super::{
     ann::{Allele, AnnField, Consequence, FeatureBiotype, FeatureType, Pos, Rank, SoFeature},
     provider::Provider as MehariProvider,
 };
-use crate::annotate::cli::ConsequenceBy;
+use crate::annotate::cli::{ConsequenceBy, TranscriptPickMode, TranscriptPickType};
 use crate::annotate::seqvars::ann::{
     ANN_AA_SEQ_ALT, ANN_AA_SEQ_REF, ANN_TX_SEQ_ALT, ANN_TX_SEQ_REF, FeatureTag, GroupedAlleles,
 };
@@ -371,16 +371,107 @@ impl ConsequencePredictor {
 
         // Get gene ids for all transcripts in `txs`, then obtain the picked transcript
         // identifiers for these genes and limit `txs` to those transcripts.
-        let picked_txs = txs
+        let static_picked_txs = txs
             .iter()
             .flat_map(|tx| self.provider.get_tx(&tx.tx_ac))
             .flat_map(|tx| self.provider.get_picked_transcripts(&tx.gene_id))
             .flatten()
             .collect::<Vec<_>>();
-        // tracing::trace!("Picked transcripts: {:?}", &picked_txs);
-        txs.into_iter()
-            .filter(|tx| picked_txs.contains(&tx.tx_ac))
-            .collect::<Vec<_>>()
+
+        let overlapping_txs: Vec<_> = txs
+            .into_iter()
+            .filter(|tx| static_picked_txs.contains(&tx.tx_ac))
+            .collect();
+
+        if !self
+            .provider
+            .pick_transcript
+            .contains(&TranscriptPickType::Length)
+        {
+            return overlapping_txs;
+        }
+
+        let mut by_gene: std::collections::HashMap<String, Vec<TxForRegionRecord>> =
+            std::collections::HashMap::new();
+        for tx in &overlapping_txs {
+            if let Some(t) = self.provider.get_tx(&tx.tx_ac) {
+                by_gene
+                    .entry(t.gene_id.clone())
+                    .or_default()
+                    .push(tx.clone());
+            }
+        }
+
+        let mut dynamic_picked = Vec::new();
+
+        for (_, gene_txs) in by_gene {
+            if gene_txs.is_empty() {
+                continue;
+            }
+            if gene_txs.len() == 1 {
+                dynamic_picked.push(gene_txs[0].clone());
+                continue;
+            }
+
+            // find the longest transcript among those that actually overlap the variant,
+            // strictly preferring protein-coding and "clean" transcripts.
+            let longest = gene_txs
+                .iter()
+                .max_by_key(|tx| {
+                    self.provider
+                        .get_tx(&tx.tx_ac)
+                        .map(|t| {
+                            let is_coding = TranscriptBiotype::try_from(t.biotype)
+                                .unwrap_or(TranscriptBiotype::Unknown)
+                                == TranscriptBiotype::Coding;
+
+                            let is_clean = t.is_clean();
+                            let length = crate::annotate::seqvars::provider::transcript_length(t);
+
+                            (is_coding, is_clean, length)
+                        })
+                        .unwrap_or((false, false, 0))
+                })
+                .cloned()
+                .unwrap();
+
+            match self.provider.pick_transcript_mode {
+                TranscriptPickMode::First => {
+                    // for First mode, if we reach this point with more than one overlapping transcript,
+                    // it means the static phase deferred straight to Length.
+                    dynamic_picked.push(longest);
+                }
+                TranscriptPickMode::All => {
+                    // in All mode, we keep the longest, but also ensure we keep any transcripts
+                    // that satisfied other static picking tags (like ManeSelect).
+                    for tx in gene_txs {
+                        let mut keep = false;
+                        if tx.tx_ac == longest.tx_ac {
+                            keep = true;
+                        } else if let Some(t) = self.provider.get_tx(&tx.tx_ac) {
+                            let tags: Vec<_> = t
+                                .tags
+                                .iter()
+                                .filter_map(crate::annotate::seqvars::provider::tag_to_picktype)
+                                .collect();
+                            for pick in &self.provider.pick_transcript {
+                                if *pick != TranscriptPickType::Length && tags.contains(pick) {
+                                    keep = true;
+                                    break;
+                                }
+                            }
+                        }
+                        if keep {
+                            dynamic_picked.push(tx);
+                        }
+                    }
+                }
+            }
+        }
+
+        // re-sort the final filtered list to maintain a deterministic order
+        dynamic_picked.sort_by(|a, b| a.tx_ac.cmp(&b.tx_ac));
+        dynamic_picked
     }
 
     /// Filter the ANN fields depending on the configuration.
@@ -394,9 +485,13 @@ impl ConsequencePredictor {
 
         /// Return sort order for ANN biotype, gives priority to ManeSelect and ManePlusClinical.
         fn tag_order(tags: &[FeatureTag]) -> i32 {
-            if tags.contains(&FeatureTag::ManeSelect) {
+            if tags.contains(&FeatureTag::ManeSelect)
+                || tags.contains(&FeatureTag::ManeSelectBackport)
+            {
                 0
-            } else if tags.contains(&FeatureTag::ManePlusClinical) {
+            } else if tags.contains(&FeatureTag::ManePlusClinical)
+                || tags.contains(&FeatureTag::ManePlusClinicalBackport)
+            {
                 1
             } else {
                 2

--- a/mehari/src/annotate/seqvars/csq.rs
+++ b/mehari/src/annotate/seqvars/csq.rs
@@ -362,38 +362,16 @@ impl ConsequencePredictor {
         }
     }
 
-    // Filter transcripts to the picked ones from the selected transcript source.
     fn filter_picked_sourced_txs(&self, txs: Vec<TxForRegionRecord>) -> Vec<TxForRegionRecord> {
-        // Short-circuit if transcript picking has been disabled.
+        // If no picking is requested, return all overlapping transcripts
         if !self.provider.transcript_picking() {
             return txs;
         }
 
-        // Get gene ids for all transcripts in `txs`, then obtain the picked transcript
-        // identifiers for these genes and limit `txs` to those transcripts.
-        let static_picked_txs = txs
-            .iter()
-            .flat_map(|tx| self.provider.get_tx(&tx.tx_ac))
-            .flat_map(|tx| self.provider.get_picked_transcripts(&tx.gene_id))
-            .flatten()
-            .collect::<Vec<_>>();
-
-        let overlapping_txs: Vec<_> = txs
-            .into_iter()
-            .filter(|tx| static_picked_txs.contains(&tx.tx_ac))
-            .collect();
-
-        if !self
-            .provider
-            .pick_transcript
-            .contains(&TranscriptPickType::Length)
-        {
-            return overlapping_txs;
-        }
-
+        // Group the physically OVERLAPPING transcripts by gene
         let mut by_gene: std::collections::HashMap<String, Vec<TxForRegionRecord>> =
             std::collections::HashMap::new();
-        for tx in &overlapping_txs {
+        for tx in &txs {
             if let Some(t) = self.provider.get_tx(&tx.tx_ac) {
                 by_gene
                     .entry(t.gene_id.clone())
@@ -408,68 +386,123 @@ impl ConsequencePredictor {
             if gene_txs.is_empty() {
                 continue;
             }
+
+            // If only one transcript overlaps, it wins by default
             if gene_txs.len() == 1 {
                 dynamic_picked.push(gene_txs[0].clone());
                 continue;
             }
 
-            // find the longest transcript among those that actually overlap the variant,
-            // strictly preferring protein-coding and "clean" transcripts.
-            let longest = gene_txs
-                .iter()
-                .max_by_key(|tx| {
-                    self.provider
-                        .get_tx(&tx.tx_ac)
-                        .map(|t| {
-                            let is_coding = TranscriptBiotype::try_from(t.biotype)
-                                .unwrap_or(TranscriptBiotype::Unknown)
-                                == TranscriptBiotype::Coding;
-
-                            let is_clean = t.is_clean();
-                            let length = crate::annotate::seqvars::provider::transcript_length(t);
-
-                            (is_coding, is_clean, length)
-                        })
-                        .unwrap_or((false, false, 0))
-                })
-                .cloned()
-                .unwrap();
+            // Helper to find the "smart longest" among a subset of transcripts
+            let find_longest = |subset: &[TxForRegionRecord]| -> TxForRegionRecord {
+                subset
+                    .iter()
+                    .max_by_key(|tx| {
+                        self.provider
+                            .get_tx(&tx.tx_ac)
+                            .map(|t| {
+                                let is_coding = TranscriptBiotype::try_from(t.biotype)
+                                    .unwrap_or(TranscriptBiotype::Unknown)
+                                    == TranscriptBiotype::Coding;
+                                let is_clean = t.is_clean();
+                                let length =
+                                    crate::annotate::seqvars::provider::transcript_length(t);
+                                (is_coding, is_clean, length)
+                            })
+                            .unwrap_or((false, false, 0))
+                    })
+                    .cloned()
+                    .unwrap()
+            };
 
             match self.provider.pick_transcript_mode {
                 TranscriptPickMode::First => {
-                    // for First mode, if we reach this point with more than one overlapping transcript,
-                    // it means the static phase deferred straight to Length.
-                    dynamic_picked.push(longest);
+                    let mut resolved = None;
+
+                    // Evaluate criteria in strict CLI order against the OVERLAPPING transcripts
+                    for pick in &self.provider.pick_transcript {
+                        if *pick == TranscriptPickType::Length {
+                            resolved = Some(find_longest(&gene_txs));
+                            break;
+                        } else {
+                            let matched: Vec<_> = gene_txs
+                                .iter()
+                                .filter(|tx| {
+                                    if let Some(t) = self.provider.get_tx(&tx.tx_ac) {
+                                        let tags = t
+                                            .tags
+                                            .iter()
+                                            .filter_map(
+                                                crate::annotate::seqvars::provider::tag_to_picktype,
+                                            )
+                                            .collect::<Vec<_>>();
+                                        tags.contains(pick)
+                                    } else {
+                                        false
+                                    }
+                                })
+                                .cloned()
+                                .collect();
+
+                            if !matched.is_empty() {
+                                // If multiple overlapping transcripts share the tag, break tie with length
+                                resolved = Some(find_longest(&matched));
+                                break;
+                            }
+                        }
+                    }
+
+                    // If none of the CLI criteria matched (e.g. no ManeSelect overlaps, and Length wasn't specified),
+                    // fallback to the longest overlapping transcript to ensure we don't drop the variant.
+                    if let Some(tx) = resolved {
+                        dynamic_picked.push(tx);
+                    } else {
+                        dynamic_picked.push(find_longest(&gene_txs));
+                    }
                 }
                 TranscriptPickMode::All => {
-                    // in All mode, we keep the longest, but also ensure we keep any transcripts
-                    // that satisfied other static picking tags (like ManeSelect).
-                    for tx in gene_txs {
-                        let mut keep = false;
-                        if tx.tx_ac == longest.tx_ac {
-                            keep = true;
-                        } else if let Some(t) = self.provider.get_tx(&tx.tx_ac) {
-                            let tags: Vec<_> = t
-                                .tags
+                    let mut kept_for_gene = Vec::new();
+
+                    for pick in &self.provider.pick_transcript {
+                        if *pick == TranscriptPickType::Length {
+                            let longest = find_longest(&gene_txs);
+                            if !kept_for_gene
                                 .iter()
-                                .filter_map(crate::annotate::seqvars::provider::tag_to_picktype)
-                                .collect();
-                            for pick in &self.provider.pick_transcript {
-                                if *pick != TranscriptPickType::Length && tags.contains(pick) {
-                                    keep = true;
-                                    break;
+                                .any(|tx: &TxForRegionRecord| tx.tx_ac == longest.tx_ac)
+                            {
+                                kept_for_gene.push(longest);
+                            }
+                        } else {
+                            for tx in &gene_txs {
+                                if let Some(t) = self.provider.get_tx(&tx.tx_ac) {
+                                    let tags = t
+                                        .tags
+                                        .iter()
+                                        .filter_map(
+                                            crate::annotate::seqvars::provider::tag_to_picktype,
+                                        )
+                                        .collect::<Vec<_>>();
+                                    if tags.contains(pick)
+                                        && !kept_for_gene
+                                            .iter()
+                                            .any(|kept: &TxForRegionRecord| kept.tx_ac == tx.tx_ac)
+                                    {
+                                        kept_for_gene.push(tx.clone());
+                                    }
                                 }
                             }
                         }
-                        if keep {
-                            dynamic_picked.push(tx);
-                        }
                     }
+
+                    if kept_for_gene.is_empty() {
+                        kept_for_gene.push(find_longest(&gene_txs));
+                    }
+
+                    dynamic_picked.extend(kept_for_gene);
                 }
             }
         }
 
-        // re-sort the final filtered list to maintain a deterministic order
         dynamic_picked.sort_by(|a, b| a.tx_ac.cmp(&b.tx_ac));
         dynamic_picked
     }

--- a/mehari/src/annotate/seqvars/provider.rs
+++ b/mehari/src/annotate/seqvars/provider.rs
@@ -228,6 +228,12 @@ pub struct Provider {
 
     /// The schema version.
     schema_version: String,
+
+    /// The transcript(-feature)s to pick, if any
+    pub pick_transcript: Vec<TranscriptPickType>,
+
+    /// How to handle multiple transcripts. Default is to keep all.
+    pub pick_transcript_mode: TranscriptPickMode,
 }
 
 enum ReferenceReaderImpl {
@@ -249,7 +255,7 @@ impl ReferenceReader for ReferenceReaderImpl {
     }
 }
 
-fn transcript_length(tx: &Transcript) -> i32 {
+pub(crate) fn transcript_length(tx: &Transcript) -> i32 {
     let mut max_tx_length = 0;
     for genome_alignment in tx.genome_alignments.iter() {
         // We just count length in reference so we don't have to look
@@ -263,6 +269,31 @@ fn transcript_length(tx: &Transcript) -> i32 {
         }
     }
     max_tx_length
+}
+
+pub(crate) fn tag_to_picktype(tag: &i32) -> Option<TranscriptPickType> {
+    match TranscriptTag::try_from(*tag).unwrap() {
+        TranscriptTag::Unknown | TranscriptTag::Other | TranscriptTag::OtherBackport => None,
+        TranscriptTag::Basic => Some(TranscriptPickType::Basic),
+        TranscriptTag::EnsemblCanonical => Some(TranscriptPickType::EnsemblCanonical),
+        TranscriptTag::ManeSelect => Some(TranscriptPickType::ManeSelect),
+        TranscriptTag::ManePlusClinical => Some(TranscriptPickType::ManePlusClinical),
+        TranscriptTag::RefSeqSelect => Some(TranscriptPickType::RefSeqSelect),
+        TranscriptTag::Selenoprotein => None,
+        TranscriptTag::GencodePrimary => Some(TranscriptPickType::GencodePrimary),
+        TranscriptTag::EnsemblGraft => None,
+        TranscriptTag::BasicBackport => Some(TranscriptPickType::BasicBackport),
+        TranscriptTag::EnsemblCanonicalBackport => {
+            Some(TranscriptPickType::EnsemblCanonicalBackport)
+        }
+        TranscriptTag::ManeSelectBackport => Some(TranscriptPickType::ManeSelectBackport),
+        TranscriptTag::ManePlusClinicalBackport => {
+            Some(TranscriptPickType::ManePlusClinicalBackport)
+        }
+        TranscriptTag::RefSeqSelectBackport => Some(TranscriptPickType::RefSeqSelectBackport),
+        TranscriptTag::SelenoproteinBackport => None,
+        TranscriptTag::GencodePrimaryBackport => Some(TranscriptPickType::GencodePrimaryBackport),
+    }
 }
 
 impl Provider {
@@ -408,11 +439,13 @@ impl Provider {
             reference_reader,
             data_version,
             schema_version,
+            pick_transcript: config.pick_transcript,
+            pick_transcript_mode: config.pick_transcript_mode,
         }
     }
 
     /// When transcript picking is enabled, restrict to ManeSelect and ManePlusClinical if we have any such transcript.
-    /// Otherwise, fall back to the longest transcript.
+    /// Length has to be handled explicitly after determining overlapping transcripts.
     fn picked_genes_to_tx_map(
         tx_seq_db: &mut TxSeqDatabase,
         config: &Config,
@@ -424,117 +457,62 @@ impl Provider {
         let tx_db = tx_seq_db.tx_db.as_mut().unwrap();
         let mut new_gene_to_tx = Vec::new();
 
-        fn tag_to_picktype(tag: &i32) -> Option<TranscriptPickType> {
-            match TranscriptTag::try_from(*tag).unwrap() {
-                TranscriptTag::Unknown | TranscriptTag::Other | TranscriptTag::OtherBackport => {
-                    None
-                }
-                TranscriptTag::Basic => Some(TranscriptPickType::Basic),
-                TranscriptTag::EnsemblCanonical => Some(TranscriptPickType::EnsemblCanonical),
-                TranscriptTag::ManeSelect => Some(TranscriptPickType::ManeSelect),
-                TranscriptTag::ManePlusClinical => Some(TranscriptPickType::ManePlusClinical),
-                TranscriptTag::RefSeqSelect => Some(TranscriptPickType::RefSeqSelect),
-                TranscriptTag::Selenoprotein => None,
-                TranscriptTag::GencodePrimary => Some(TranscriptPickType::GencodePrimary),
-                TranscriptTag::EnsemblGraft => None,
-                TranscriptTag::BasicBackport => Some(TranscriptPickType::BasicBackport),
-                TranscriptTag::EnsemblCanonicalBackport => {
-                    Some(TranscriptPickType::EnsemblCanonicalBackport)
-                }
-                TranscriptTag::ManeSelectBackport => Some(TranscriptPickType::ManeSelectBackport),
-                TranscriptTag::ManePlusClinicalBackport => {
-                    Some(TranscriptPickType::ManePlusClinicalBackport)
-                }
-                TranscriptTag::RefSeqSelectBackport => {
-                    Some(TranscriptPickType::RefSeqSelectBackport)
-                }
-                TranscriptTag::SelenoproteinBackport => None,
-                TranscriptTag::GencodePrimaryBackport => {
-                    Some(TranscriptPickType::GencodePrimaryBackport)
-                }
-            }
-        }
-
-        // FIXME: This source classification is a legacy artifact for VarFish TSV compatibility.
-        //   It should be removed once the varfish tsv export/import is updated.
-        let transcript_id_to_source = |tx_id: &str| -> String {
-            if tx_id.starts_with("ENST") {
-                "Ensembl".to_string()
-            } else if tx_id.starts_with('N') || tx_id.starts_with('X') {
-                "RefSeq".to_string()
-            } else {
-                // Safe fallback for arbitrary databases (e.g., TAIR10, custom assemblies)
-                "Other".to_string()
-            }
-        };
-
-        // Process each gene.
         for entry in tx_db.gene_to_tx.iter() {
-            let mut longest_tx_per_source: FxHashMap<String, (bool, usize, i32)> =
-                FxHashMap::default();
-            let mut tx_tags = entry
+            let tx_tags = entry
                 .tx_ids
                 .iter()
                 .filter_map(|tx_id| {
                     tx_map.get(tx_id).map(|tx_idx| {
                         let tx = &tx_db.transcripts[*tx_idx as usize];
                         let tags = tx.tags.iter().filter_map(tag_to_picktype).collect_vec();
-                        let length = transcript_length(tx);
-                        let source = transcript_id_to_source(tx_id);
-                        let is_clean = tx.is_clean();
-                        (tx_id, tags, length, source, is_clean)
+                        (tx_id, tags)
                     })
-                })
-                .enumerate()
-                .map(|(i, (tx_id, tags, length, source, is_clean))| {
-                    longest_tx_per_source
-                        .entry(source)
-                        .and_modify(|(prev_clean, prev_i, prev_length)| {
-                            if (is_clean, length) > (*prev_clean, *prev_length) {
-                                *prev_clean = is_clean;
-                                *prev_i = i;
-                                *prev_length = length;
-                            }
-                        })
-                        .or_insert((is_clean, i, length));
-                    (tx_id, tags, length)
                 })
                 .collect_vec();
 
-            for (_, (_, i, _)) in longest_tx_per_source.iter() {
-                tx_tags[*i].1.push(TranscriptPickType::Length);
-            }
-
             let tx_ids = match config.pick_transcript_mode {
                 TranscriptPickMode::First => {
-                    // only keep the first transcript that fulfills the transcript picking strategy,
-                    // if any
-                    let tx_id = config
-                        .pick_transcript
-                        .iter()
-                        .filter_map(|pick| {
-                            tx_tags
-                                .iter()
-                                .find(|(_, tags, _)| tags.contains(pick))
-                                .map(|(tx_id, _, _)| tx_id)
-                        })
-                        .next();
-                    if let Some(tx_id) = tx_id {
-                        vec![tx_id.to_string()]
-                    } else {
-                        vec![]
+                    let mut resolved = vec![];
+                    for pick in &config.pick_transcript {
+                        if *pick == TranscriptPickType::Length {
+                            // Defer dynamic length logic: Keep all transcripts for this gene
+                            resolved = tx_tags.iter().map(|(id, _)| id.to_string()).collect();
+                            break;
+                        }
+                        let matched: Vec<_> = tx_tags
+                            .iter()
+                            .filter(|(_, tags)| tags.contains(pick))
+                            .map(|(id, _)| id.to_string())
+                            .collect();
+                        if !matched.is_empty() {
+                            resolved = vec![matched[0].clone()];
+                            break;
+                        }
                     }
+                    resolved
                 }
                 TranscriptPickMode::All => {
-                    // keep all transcripts that fulfill the transcript picking strategy
-                    tx_tags
-                        .iter()
-                        .filter_map(|(tx_id, tags, _)| {
-                            tags.iter()
-                                .any(|tag| config.pick_transcript.contains(tag))
-                                .then_some(tx_id.to_string())
-                        })
-                        .collect()
+                    let mut resolved = vec![];
+                    let mut defer_length = false;
+                    for pick in &config.pick_transcript {
+                        if *pick == TranscriptPickType::Length {
+                            defer_length = true;
+                            continue;
+                        }
+                        resolved.extend(
+                            tx_tags
+                                .iter()
+                                .filter(|(_, tags)| tags.contains(pick))
+                                .map(|(id, _)| id.to_string()),
+                        );
+                    }
+                    if defer_length {
+                        // Defer dynamic length logic: Add all transcripts for evaluation
+                        resolved.extend(tx_tags.iter().map(|(id, _)| id.to_string()));
+                        resolved.sort();
+                        resolved.dedup();
+                    }
+                    resolved
                 }
             };
 

--- a/mehari/src/annotate/seqvars/provider.rs
+++ b/mehari/src/annotate/seqvars/provider.rs
@@ -178,6 +178,10 @@ pub struct Config {
     ///
     /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
     /// either the first one is kept or all are kept.
+    ///
+    /// Transcripts are evaluated in the order these options are provided.
+    /// To prevent variants from being completely dropped, if none of the overlapping
+    /// transcripts match the requested criteria, the longest transcript is the implicit fallback.
     #[builder(default)]
     pub pick_transcript: Vec<TranscriptPickType>,
 

--- a/mehari/src/annotate/seqvars/provider.rs
+++ b/mehari/src/annotate/seqvars/provider.rs
@@ -9,7 +9,7 @@ use crate::db::TranscriptDatabase;
 use crate::db::create::models::Reason;
 use crate::{
     annotate::seqvars::csq::ALT_ALN_METHOD,
-    pbs::txs::{GeneToTxId, Strand, Transcript, TranscriptTag, TxSeqDatabase},
+    pbs::txs::{Strand, Transcript, TranscriptTag, TxSeqDatabase},
 };
 use bio::data_structures::interval_tree::ArrayBackedIntervalTree;
 use enumflags2::BitFlags;
@@ -216,10 +216,6 @@ pub struct Provider {
     /// string used in the database (e.g. "1")
     contig_alias_map: FxHashMap<String, String>,
 
-    /// When transcript picking is enabled, contains the `GeneToTxIdx` entries
-    /// for each gene; the order matches the one of `tx_seq_db.gene_to_tx`.
-    picked_gene_to_tx_id: Option<Vec<GeneToTxId>>,
-
     /// for reading parts of reference sequences
     reference_reader: Option<ReferenceReaderImpl>,
 
@@ -303,7 +299,7 @@ impl Provider {
     ///
     /// * `tx_seq_db` - The `TxSeqDatabase` to use.
     pub fn new(
-        mut tx_seq_db: TxSeqDatabase,
+        tx_seq_db: TxSeqDatabase,
         reference: Option<impl AsRef<Path>>,
         in_memory_reference: bool,
         config: Config,
@@ -396,8 +392,6 @@ impl Provider {
                 .map(|(alias, idx)| (alias.clone(), *idx)),
         );
 
-        let picked_gene_to_tx_id = Self::picked_genes_to_tx_map(&mut tx_seq_db, &config, &tx_map);
-
         // TODO obtain or construct data_version and schema_version somehow
         // for now, these are just set to a combination of things that make this provider instance
         // unique, such that `data_version` and `schema_version` can be used as keys for
@@ -435,117 +429,12 @@ impl Provider {
             tx_map,
             seq_map,
             assembly_map,
-            picked_gene_to_tx_id,
             reference_reader,
             data_version,
             schema_version,
             pick_transcript: config.pick_transcript,
             pick_transcript_mode: config.pick_transcript_mode,
         }
-    }
-
-    /// When transcript picking is enabled, restrict to ManeSelect and ManePlusClinical if we have any such transcript.
-    /// Length has to be handled explicitly after determining overlapping transcripts.
-    fn picked_genes_to_tx_map(
-        tx_seq_db: &mut TxSeqDatabase,
-        config: &Config,
-        tx_map: &FxHashMap<String, u32>,
-    ) -> Option<Vec<GeneToTxId>> {
-        if config.pick_transcript.is_empty() || tx_seq_db.tx_db.is_none() {
-            return None;
-        }
-        let tx_db = tx_seq_db.tx_db.as_mut().unwrap();
-        let mut new_gene_to_tx = Vec::new();
-
-        for entry in tx_db.gene_to_tx.iter() {
-            let tx_tags = entry
-                .tx_ids
-                .iter()
-                .filter_map(|tx_id| {
-                    tx_map.get(tx_id).map(|tx_idx| {
-                        let tx = &tx_db.transcripts[*tx_idx as usize];
-                        let tags = tx.tags.iter().filter_map(tag_to_picktype).collect_vec();
-                        (tx_id, tags)
-                    })
-                })
-                .collect_vec();
-
-            let tx_ids = match config.pick_transcript_mode {
-                TranscriptPickMode::First => {
-                    let mut resolved = vec![];
-                    for pick in &config.pick_transcript {
-                        if *pick == TranscriptPickType::Length {
-                            // Defer dynamic length logic: Keep all transcripts for this gene
-                            resolved = tx_tags.iter().map(|(id, _)| id.to_string()).collect();
-                            break;
-                        }
-                        let matched: Vec<_> = tx_tags
-                            .iter()
-                            .filter(|(_, tags)| tags.contains(pick))
-                            .map(|(id, _)| id.to_string())
-                            .collect();
-                        if !matched.is_empty() {
-                            resolved = vec![matched[0].clone()];
-                            break;
-                        }
-                    }
-                    resolved
-                }
-                TranscriptPickMode::All => {
-                    let mut resolved = vec![];
-                    let mut defer_length = false;
-                    for pick in &config.pick_transcript {
-                        if *pick == TranscriptPickType::Length {
-                            defer_length = true;
-                            continue;
-                        }
-                        resolved.extend(
-                            tx_tags
-                                .iter()
-                                .filter(|(_, tags)| tags.contains(pick))
-                                .map(|(id, _)| id.to_string()),
-                        );
-                    }
-                    if defer_length {
-                        // Defer dynamic length logic: Add all transcripts for evaluation
-                        resolved.extend(tx_tags.iter().map(|(id, _)| id.to_string()));
-                        resolved.sort();
-                        resolved.dedup();
-                    }
-                    resolved
-                }
-            };
-
-            let new_entry = if !tx_ids.is_empty() {
-                GeneToTxId {
-                    gene_id: entry.gene_id.clone(),
-                    tx_ids,
-                    filtered: Some(false),
-                    filter_reason: None,
-                }
-            } else {
-                tracing::trace!(
-                    "no transcript found for gene {} with the chosen transcript picking strategy: {:?}",
-                    &entry.gene_id,
-                    &config.pick_transcript
-                );
-                GeneToTxId {
-                    gene_id: entry.gene_id.clone(),
-                    tx_ids: vec![],
-                    filtered: Some(true),
-                    filter_reason: Some(Reason::NoTranscriptLeft as u32),
-                }
-            };
-
-            tracing::trace!(
-                "picked transcripts {:?} for gene {}",
-                new_entry.tx_ids,
-                new_entry.gene_id
-            );
-            new_gene_to_tx.push(new_entry);
-        }
-
-        Some(new_gene_to_tx)
     }
 
     /// Return the assembly of the provider.
@@ -559,7 +448,7 @@ impl Provider {
 
     /// Return whether transcript picking is enabled.
     pub fn transcript_picking(&self) -> bool {
-        self.picked_gene_to_tx_id.is_some()
+        !self.pick_transcript.is_empty()
     }
 
     /// Return the picked transcript IDs for a gene.
@@ -573,19 +462,9 @@ impl Provider {
     /// The picked transcript IDs, or None if the gene is not found.
     pub fn get_picked_transcripts(&self, hgnc_id: &str) -> Option<Vec<String>> {
         self.gene_map.get(hgnc_id).and_then(|gene_idx| {
-            let gene_to_tx = if let Some(picked_gene_to_tx_id) = self.picked_gene_to_tx_id.as_ref()
-            {
-                picked_gene_to_tx_id
-            } else {
-                &self.tx_seq_db.tx_db.as_ref().expect("no tx_db?").gene_to_tx
-            };
-
-            // tracing::trace!(
-            //     "get_picked_transcripts({}) = {:?}",
-            //     hgnc_id,
-            //     &gene_to_tx[*gene_idx as usize].tx_ids
-            // );
+            let gene_to_tx = &self.tx_seq_db.tx_db.as_ref().expect("no tx_db?").gene_to_tx;
             let gene = &gene_to_tx[*gene_idx as usize];
+
             if let Some(true) = gene.filtered {
                 None
             } else {

--- a/mehari/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_snv_ttn_transcript_picking_reporting@2-179631246-G-A-false-false.snap
+++ b/mehari/src/annotate/seqvars/snapshots/mehari__annotate__seqvars__csq__test__annotate_snv_ttn_transcript_picking_reporting@2-179631246-G-A-false-false.snap
@@ -1,6 +1,7 @@
 ---
 source: mehari/src/annotate/seqvars/csq.rs
 expression: res
+snapshot_kind: text
 ---
 - allele:
     Alt:
@@ -13,26 +14,28 @@ expression: res
   feature_type:
     so_term:
       term: Transcript
-  feature_id: NM_001256850.1
+  feature_id: NM_001267550.2
   feature_biotype:
     - coding
-  feature_tags: []
+  feature_tags:
+    - ref_seq_select
+    - mane_select_backport
   rank:
     ord: 41
-    total: 313
+    total: 363
   hgvs_g: g.179631246G>A
   hgvs_n: n.9790C>T
   hgvs_c: c.9565C>T
   hgvs_p: p.Gln3189Ter
   cdna_pos:
     ord: 9790
-    total: 104301
+    total: 109224
   cds_pos:
     ord: 9565
-    total: 103053
+    total: 107976
   protein_pos:
     ord: 3189
-    total: 34351
+    total: 35992
   distance: 0
   strand: -1
   messages: ~

--- a/mehari/src/db/subset/mod.rs
+++ b/mehari/src/db/subset/mod.rs
@@ -8,7 +8,7 @@ use crate::pbs::txs::{TranscriptDb, TxSeqDatabase};
 use anyhow::{Error, Result};
 use clap::Parser;
 use indexmap::{IndexMap, IndexSet};
-use noodles::core::{Position, Region};
+use noodles::core::Region;
 use noodles::vcf::variant::Record;
 use prost::Message as _;
 use std::collections::Bound;

--- a/mehari/src/verify/seqvars.rs
+++ b/mehari/src/verify/seqvars.rs
@@ -47,6 +47,10 @@ pub struct Args {
     ///
     /// Depending on `--pick-transcript-mode`, if multiple transcripts match the selection,
     /// either the first one is kept or all are kept.
+    ///
+    /// Transcripts are evaluated in the order these options are provided.
+    /// To prevent variants from being completely dropped, if none of the overlapping
+    /// transcripts match the requested criteria, the longest transcript is the implicit fallback.
     #[arg(long)]
     pub pick_transcript: Vec<TranscriptPickType>,
 


### PR DESCRIPTION
When combining `--pick-mode first` and `--pick-transcript length`, the length (aka longest transcript) would be determined up-front per-gene before determining variant overlapping transcripts. This PR fixes this behaviour such that the longest transcript is now only determined from the actually available transcripts (all other picks such as `--pick-transcript mane-select` can still be done once up-front because they are static anyway).
Also fixes ordering of transcripts within one record for grch37 + mane-select (backport) tags


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Transcript selection now supports flexible modes with dynamic gene-specific prioritization
  * Expanded variant annotation with improved handling of specialized variant types
  * Refined transcript filtering and consequence reporting based on enhanced prioritization rules
  * Updated annotation configuration for better control over transcript selection behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->