### PR TITLE
fix: varfish postprocess TSV assembly capitalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287d8d3ebdce117b8539f59411e4ed9ec226e0a4153c7f55495c6070d68e6f72"
+checksum = "e78deb158fb1d73b29efb4b7e9b9860b78059c670de06bd28df8d0b458ded0eb"
 dependencies = [
  "parse-display-derive",
  "regex",
@@ -3557,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc048687be30d79502dea2f623d052f3a074012c6eac41726b7ab17213616b1"
+checksum = "8e95a50d1084dab562913062c4c34bb204b68fc6ec38a1395909ff5aaaf4f10a"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",

--- a/mehari-python/Cargo.lock
+++ b/mehari-python/Cargo.lock
@@ -3136,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287d8d3ebdce117b8539f59411e4ed9ec226e0a4153c7f55495c6070d68e6f72"
+checksum = "e78deb158fb1d73b29efb4b7e9b9860b78059c670de06bd28df8d0b458ded0eb"
 dependencies = [
  "parse-display-derive",
  "regex",
@@ -3147,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc048687be30d79502dea2f623d052f3a074012c6eac41726b7ab17213616b1"
+checksum = "8e95a50d1084dab562913062c4c34bb204b68fc6ec38a1395909ff5aaaf4f10a"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",

--- a/mehari/src/postprocess/varfish.rs
+++ b/mehari/src/postprocess/varfish.rs
@@ -67,7 +67,7 @@ pub async fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyho
         s => {
             warn!(
                 "Unrecognized assembly '{}', using as-is in TSV output",
-                args.assembly.as_ref()
+                &args.assembly
             );
             args.assembly.as_ref()
         }

--- a/mehari/src/postprocess/varfish.rs
+++ b/mehari/src/postprocess/varfish.rs
@@ -64,7 +64,7 @@ pub async fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyho
     let assembly = match args.assembly.to_lowercase().as_ref() {
         "grch37" => "GRCh37",
         "grch38" => "GRCh38",
-        s => {
+        _ => {
             warn!(
                 "Unrecognized assembly '{}', using as-is in TSV output",
                 &args.assembly

--- a/mehari/src/postprocess/varfish.rs
+++ b/mehari/src/postprocess/varfish.rs
@@ -10,6 +10,7 @@ use clap::Parser;
 use flate2::Compression;
 use flate2::write::GzEncoder;
 use futures::TryStreamExt;
+use log::warn;
 use noodles::vcf::Header as VcfHeader;
 use noodles::vcf::variant::record::samples::keys::key::{
     CONDITIONAL_GENOTYPE_QUALITY, GENOTYPE, READ_DEPTH,
@@ -60,7 +61,18 @@ pub async fn run(_common: &crate::common::Args, args: &Args) -> Result<(), anyho
 
     let mut reader = open_variant_reader(&args.input).await?;
     let header = reader.read_header().await?;
-    let assembly = args.assembly.clone();
+    let assembly = match args.assembly.to_lowercase().as_ref() {
+        "grch37" => "GRCh37",
+        "grch38" => "GRCh38",
+        s => {
+            warn!(
+                "Unrecognized assembly '{}', using as-is in TSV output",
+                args.assembly.as_ref()
+            );
+            args.assembly.as_ref()
+        }
+    }
+    .to_string();
 
     // 3. Initialize TSV Writer
     let mut writer = VarFishSeqvarTsvWriter::from_path(&args.output, args.tsv_contig_style)?;


### PR DESCRIPTION
<!--

NOTE
NOTE In most cases, you should create an issue first, and only then
NOTE a pull request.  Please see the contribution guidelines for
NOTE further information.  In particular related to conventional
NOTE commit messages.
NOTE

The title should have the following format:

  <type>: description (#<issue>)

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved assembly argument handling to accept and normalize case-insensitive assembly identifiers (e.g., `grch37`, `GRCh37`).
  * Added warning messages for unrecognized assembly values to improve troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->