### PR TITLE
fix: more robust freqs/clinvar assembly checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287d8d3ebdce117b8539f59411e4ed9ec226e0a4153c7f55495c6070d68e6f72"
+checksum = "e78deb158fb1d73b29efb4b7e9b9860b78059c670de06bd28df8d0b458ded0eb"
 dependencies = [
  "parse-display-derive",
  "regex",
@@ -3557,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc048687be30d79502dea2f623d052f3a074012c6eac41726b7ab17213616b1"
+checksum = "8e95a50d1084dab562913062c4c34bb204b68fc6ec38a1395909ff5aaaf4f10a"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",

--- a/mehari-python/Cargo.lock
+++ b/mehari-python/Cargo.lock
@@ -3136,9 +3136,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287d8d3ebdce117b8539f59411e4ed9ec226e0a4153c7f55495c6070d68e6f72"
+checksum = "e78deb158fb1d73b29efb4b7e9b9860b78059c670de06bd28df8d0b458ded0eb"
 dependencies = [
  "parse-display-derive",
  "regex",
@@ -3147,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "parse-display-derive"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc048687be30d79502dea2f623d052f3a074012c6eac41726b7ab17213616b1"
+checksum = "8e95a50d1084dab562913062c4c34bb204b68fc6ec38a1395909ff5aaaf4f10a"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -817,16 +817,14 @@ impl FrequencyAnnotator {
         let contig_manager = &self.contig_manager;
         // Only attempt lookups into RocksDB for canonical contigs.
         if contig_manager.is_canonical_alias(vcf_var.chrom.as_str()) {
-            let mut normalized_var = vcf_var.clone();
-            normalized_var.chrom = ContigManager::canonicalize(&normalized_var.chrom);
+            // Build key for RocksDB database from `vcf_var`.
+            let key: Vec<u8> = vcf_var.clone().into();
 
-            let key: Vec<u8> = normalized_var.clone().into();
-
-            if contig_manager.is_autosomal_alias(&normalized_var.chrom) {
+            if contig_manager.is_autosomal_alias(&vcf_var.chrom) {
                 return self.annotate_record_auto(&key);
-            } else if contig_manager.is_gonosomal_alias(&normalized_var.chrom) {
+            } else if contig_manager.is_gonosomal_alias(&vcf_var.chrom) {
                 return self.annotate_record_xy(&key);
-            } else if contig_manager.is_mitochondrial_alias(&normalized_var.chrom) {
+            } else if contig_manager.is_mitochondrial_alias(&vcf_var.chrom) {
                 return self.annotate_record_mt(&key);
             }
         }
@@ -848,7 +846,7 @@ impl FrequencyAnnotator {
 
         // Build key for RocksDB database
         let vcf_var = keys::Var::from(
-            &ContigManager::canonicalize(&vcf_var.chromosome),
+            &vcf_var.chromosome,
             vcf_var.position,
             &vcf_var.reference,
             &vcf_var.alternative,
@@ -994,10 +992,7 @@ impl ClinvarAnnotator {
             .contig_manager
             .is_canonical_alias(vcf_var.chrom.as_str())
         {
-            let mut normalized_var = vcf_var.clone();
-            normalized_var.chrom = ContigManager::canonicalize(&normalized_var.chrom);
-
-            let key: Vec<u8> = normalized_var.into();
+            let key: Vec<u8> = vcf_var.into();
             return self.annotate_record_clinvar(&key);
         }
         Ok(None)
@@ -1009,11 +1004,9 @@ impl ClinvarAnnotator {
         vcf_var: &VcfVariant,
     ) -> anyhow::Result<Option<crate::server::run::actix_server::seqvars_clinvar::ClinvarResultEntry>>
     {
-        let chrom = ContigManager::canonicalize(&vcf_var.chromosome);
-
         // Build key for RocksDB database
         let vcf_var = keys::Var::from(
-            &chrom,
+            &vcf_var.chromosome,
             vcf_var.position,
             &vcf_var.reference,
             &vcf_var.alternative,

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -848,7 +848,7 @@ impl FrequencyAnnotator {
 
         // Build key for RocksDB database
         let vcf_var = keys::Var::from(
-            &annonars::common::cli::canonicalize(&vcf_var.chromosome),
+            &ContigManager::canonicalize(&vcf_var.chromosome),
             vcf_var.position,
             &vcf_var.reference,
             &vcf_var.alternative,

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -818,7 +818,7 @@ impl FrequencyAnnotator {
         // Only attempt lookups into RocksDB for canonical contigs.
         if contig_manager.is_canonical_alias(vcf_var.chrom.as_str()) {
             let mut normalized_var = vcf_var.clone();
-            normalized_var.chrom = annonars::common::cli::canonicalize(&normalized_var.chrom);
+            normalized_var.chrom = ContigManager::canonicalize(&normalized_var.chrom);
 
             let key: Vec<u8> = normalized_var.clone().into();
 
@@ -995,7 +995,7 @@ impl ClinvarAnnotator {
             .is_canonical_alias(vcf_var.chrom.as_str())
         {
             let mut normalized_var = vcf_var.clone();
-            normalized_var.chrom = annonars::common::cli::canonicalize(&normalized_var.chrom);
+            normalized_var.chrom = ContigManager::canonicalize(&normalized_var.chrom);
 
             let key: Vec<u8> = normalized_var.into();
             return self.annotate_record_clinvar(&key);

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -820,6 +820,7 @@ impl FrequencyAnnotator {
             // Build key for RocksDB database from `vcf_var`.
             let key: Vec<u8> = vcf_var.clone().into();
 
+            // Annotate with frequency.
             if contig_manager.is_autosomal_alias(&vcf_var.chrom) {
                 return self.annotate_record_auto(&key);
             } else if contig_manager.is_gonosomal_alias(&vcf_var.chrom) {
@@ -992,7 +993,8 @@ impl ClinvarAnnotator {
             .contig_manager
             .is_canonical_alias(vcf_var.chrom.as_str())
         {
-            let key: Vec<u8> = vcf_var.into();
+            // Build key for RocksDB database from `vcf_var`.
+            let key: Vec<u8> = vcf_var.clone().into();
             return self.annotate_record_clinvar(&key);
         }
         Ok(None)

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -1009,12 +1009,7 @@ impl ClinvarAnnotator {
         vcf_var: &VcfVariant,
     ) -> anyhow::Result<Option<crate::server::run::actix_server::seqvars_clinvar::ClinvarResultEntry>>
     {
-        let contig_manager = &self.contig_manager;
-
-        let mut chrom = vcf_var.chromosome.clone();
-        if let Some(primary) = contig_manager.get_primary_name(&chrom) {
-            chrom = primary.clone();
-        }
+        let chrom = ContigManager::canonicalize(&vcf_var.chromosome);
 
         // Build key for RocksDB database
         let vcf_var = keys::Var::from(

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -1579,6 +1579,12 @@ pub(crate) fn setup_seqvars_annotator(
             &assembly,
             contig_manager.clone(),
         )?;
+        if freq_dbs.is_empty() && !rocksdb_paths.is_empty() {
+            anyhow::bail!(
+                "Frequency paths were provided but no frequency databases could be initialized for assembly '{}'",
+                assembly
+            );
+        }
         for freq_db in freq_dbs {
             annotators.push(AnnotatorEnum::Frequency(freq_db))
         }
@@ -1591,6 +1597,12 @@ pub(crate) fn setup_seqvars_annotator(
             &assembly,
             contig_manager.clone(),
         )?;
+        if clinvar_dbs.is_empty() && !rocksdb_paths.is_empty() {
+            anyhow::bail!(
+                "ClinVar paths were provided but no ClinVar databases could be initialized for assembly '{}'",
+                assembly
+            );
+        }
         for clinvar_db in clinvar_dbs {
             annotators.push(AnnotatorEnum::Clinvar(clinvar_db))
         }

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -818,11 +818,7 @@ impl FrequencyAnnotator {
         // Only attempt lookups into RocksDB for canonical contigs.
         if contig_manager.is_canonical_alias(vcf_var.chrom.as_str()) {
             let mut normalized_var = vcf_var.clone();
-
-            // Normalize "chr1" -> "1" so it matches the RocksDB keys
-            if let Some(primary) = contig_manager.get_primary_name(&normalized_var.chrom) {
-                normalized_var.chrom = primary.clone();
-            }
+            normalized_var.chrom = annonars::common::cli::canonicalize(&normalized_var.chrom);
 
             let key: Vec<u8> = normalized_var.clone().into();
 
@@ -850,14 +846,9 @@ impl FrequencyAnnotator {
             return Ok(None);
         }
 
-        let mut chrom = vcf_var.chromosome.clone();
-        if let Some(primary) = contig_manager.get_primary_name(&chrom) {
-            chrom = primary.clone();
-        }
-
         // Build key for RocksDB database
         let vcf_var = keys::Var::from(
-            &chrom,
+            &annonars::common::cli::canonicalize(&vcf_var.chromosome),
             vcf_var.position,
             &vcf_var.reference,
             &vcf_var.alternative,
@@ -1004,10 +995,7 @@ impl ClinvarAnnotator {
             .is_canonical_alias(vcf_var.chrom.as_str())
         {
             let mut normalized_var = vcf_var.clone();
-
-            if let Some(primary) = self.contig_manager.get_primary_name(&normalized_var.chrom) {
-                normalized_var.chrom = primary.clone();
-            }
+            normalized_var.chrom = annonars::common::cli::canonicalize(&normalized_var.chrom);
 
             let key: Vec<u8> = normalized_var.into();
             return self.annotate_record_clinvar(&key);

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -1670,29 +1670,28 @@ pub(crate) fn initialize_clinvar_annotators_for_assembly(
     assembly: &str,
     contig_manager: Arc<ContigManager>,
 ) -> Result<Vec<ClinvarAnnotator>, Error> {
-    rocksdb_paths
-        .iter()
-        .filter_map(|rocksdb_path| {
-            let skip = !rocksdb_path.contains(assembly);
-            if !skip {
-                tracing::info!(
-                    "Loading ClinVar database for assembly {:?} from {}",
-                    &assembly,
-                    &rocksdb_path
-                );
-                Some(ClinvarAnnotator::from_path(
-                    rocksdb_path,
-                    contig_manager.clone(),
-                ))
-            } else {
-                tracing::warn!(
-                "Skipping ClinVar database as its assembly does not match the requested one ({:?})",
-                &assembly
+    let mut annotators = Vec::new();
+    let assembly_lower = assembly.to_lowercase();
+
+    for rocksdb_path in rocksdb_paths {
+        if rocksdb_path.to_lowercase().contains(&assembly_lower) {
+            tracing::info!(
+                "Loading ClinVar database for assembly {:?} from {}",
+                assembly,
+                rocksdb_path
             );
-                None
-            }
-        })
-        .collect()
+            let annotator = ClinvarAnnotator::from_path(rocksdb_path, contig_manager.clone())?;
+            annotators.push(annotator);
+        } else {
+            anyhow::bail!(
+                "ClinVar database path '{}' does not match the active assembly '{}'. \
+                 Please ensure the path matches the correct genome build, or adjust your path naming.",
+                rocksdb_path,
+                assembly
+            );
+        }
+    }
+    Ok(annotators)
 }
 
 pub(crate) fn initialize_frequency_annotators_for_assembly(
@@ -1700,20 +1699,28 @@ pub(crate) fn initialize_frequency_annotators_for_assembly(
     assembly: &str,
     contig_manager: Arc<ContigManager>,
 ) -> Result<Vec<FrequencyAnnotator>, Error> {
-    rocksdb_paths.iter().filter_map(|rocksdb_path| {
-        let skip = !rocksdb_path.contains(assembly);
-        if !skip {
+    let mut annotators = Vec::new();
+    let assembly_lower = assembly.to_lowercase();
+
+    for rocksdb_path in rocksdb_paths {
+        if rocksdb_path.to_lowercase().contains(&assembly_lower) {
             tracing::info!(
-                    "Loading frequency database for assembly {:?} from {}",
-                    &assembly,
-                    &rocksdb_path
-                );
-            Some(FrequencyAnnotator::from_path(rocksdb_path, contig_manager.clone()))
+                "Loading frequency database for assembly {:?} from {}",
+                assembly,
+                rocksdb_path
+            );
+            let annotator = FrequencyAnnotator::from_path(rocksdb_path, contig_manager.clone())?;
+            annotators.push(annotator);
         } else {
-            tracing::warn!("Skipping frequency database as its assembly does not match the requested one ({:?})", &assembly);
-            None
+            anyhow::bail!(
+                "Frequency database path '{}' does not match the active assembly '{}'. \
+                 Please ensure the path matches the correct genome build, or adjust your path naming.",
+                rocksdb_path,
+                assembly
+            );
         }
-    }).collect()
+    }
+    Ok(annotators)
 }
 
 pub(crate) fn load_transcript_dbs_for_assembly(

--- a/mehari/src/annotate/seqvars/mod.rs
+++ b/mehari/src/annotate/seqvars/mod.rs
@@ -817,15 +817,20 @@ impl FrequencyAnnotator {
         let contig_manager = &self.contig_manager;
         // Only attempt lookups into RocksDB for canonical contigs.
         if contig_manager.is_canonical_alias(vcf_var.chrom.as_str()) {
-            // Build key for RocksDB database from `vcf_var`.
-            let key: Vec<u8> = vcf_var.clone().into();
+            let mut normalized_var = vcf_var.clone();
 
-            // Annotate with frequency.
-            if contig_manager.is_autosomal_alias(&vcf_var.chrom) {
+            // Normalize "chr1" -> "1" so it matches the RocksDB keys
+            if let Some(primary) = contig_manager.get_primary_name(&normalized_var.chrom) {
+                normalized_var.chrom = primary.clone();
+            }
+
+            let key: Vec<u8> = normalized_var.clone().into();
+
+            if contig_manager.is_autosomal_alias(&normalized_var.chrom) {
                 return self.annotate_record_auto(&key);
-            } else if contig_manager.is_gonosomal_alias(&vcf_var.chrom) {
+            } else if contig_manager.is_gonosomal_alias(&normalized_var.chrom) {
                 return self.annotate_record_xy(&key);
-            } else if contig_manager.is_mitochondrial_alias(&vcf_var.chrom) {
+            } else if contig_manager.is_mitochondrial_alias(&normalized_var.chrom) {
                 return self.annotate_record_mt(&key);
             }
         }
@@ -845,9 +850,14 @@ impl FrequencyAnnotator {
             return Ok(None);
         }
 
+        let mut chrom = vcf_var.chromosome.clone();
+        if let Some(primary) = contig_manager.get_primary_name(&chrom) {
+            chrom = primary.clone();
+        }
+
         // Build key for RocksDB database
         let vcf_var = keys::Var::from(
-            &vcf_var.chromosome,
+            &chrom,
             vcf_var.position,
             &vcf_var.reference,
             &vcf_var.alternative,
@@ -993,8 +1003,13 @@ impl ClinvarAnnotator {
             .contig_manager
             .is_canonical_alias(vcf_var.chrom.as_str())
         {
-            // Build key for RocksDB database from `vcf_var`.
-            let key: Vec<u8> = vcf_var.clone().into();
+            let mut normalized_var = vcf_var.clone();
+
+            if let Some(primary) = self.contig_manager.get_primary_name(&normalized_var.chrom) {
+                normalized_var.chrom = primary.clone();
+            }
+
+            let key: Vec<u8> = normalized_var.into();
             return self.annotate_record_clinvar(&key);
         }
         Ok(None)
@@ -1006,9 +1021,16 @@ impl ClinvarAnnotator {
         vcf_var: &VcfVariant,
     ) -> anyhow::Result<Option<crate::server::run::actix_server::seqvars_clinvar::ClinvarResultEntry>>
     {
+        let contig_manager = &self.contig_manager;
+
+        let mut chrom = vcf_var.chromosome.clone();
+        if let Some(primary) = contig_manager.get_primary_name(&chrom) {
+            chrom = primary.clone();
+        }
+
         // Build key for RocksDB database
         let vcf_var = keys::Var::from(
-            &vcf_var.chromosome,
+            &chrom,
             vcf_var.position,
             &vcf_var.reference,
             &vcf_var.alternative,

--- a/mehari/src/common/contig.rs
+++ b/mehari/src/common/contig.rs
@@ -252,4 +252,128 @@ impl ContigManager {
     pub fn sequences(&self) -> impl Iterator<Item = &Sequence> {
         self.accession_to_info.values()
     }
+
+    /// Canonicalize an alias to be used as a key for annonars' DB accesses.
+    /// Basically strips leading "chr" and converts "M" to "MT".
+    #[inline]
+    pub fn canonicalize(alias: &str) -> String {
+        annonars::common::cli::canonicalize(alias)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn get_manager() -> ContigManager {
+        ContigManager::new("grch37")
+    }
+
+    #[test]
+    fn test_canonicalize() {
+        assert_eq!(ContigManager::canonicalize("chr1"), "1");
+        assert_eq!(ContigManager::canonicalize("1"), "1");
+        assert_eq!(ContigManager::canonicalize("chrX"), "X");
+        assert_eq!(ContigManager::canonicalize("chrM"), "MT");
+        assert_eq!(ContigManager::canonicalize("M"), "MT");
+        assert_eq!(ContigManager::canonicalize("MT"), "MT");
+    }
+
+    #[test]
+    fn test_is_canonical_alias() {
+        let cm = get_manager();
+
+        assert!(cm.is_canonical_alias("chr1"));
+        assert!(cm.is_canonical_alias("1"));
+        assert!(cm.is_canonical_alias("NC_000001.10")); // GRCh37 chr1
+        assert!(cm.is_canonical_alias("chrX"));
+        assert!(cm.is_canonical_alias("chrY"));
+        assert!(cm.is_canonical_alias("chrM"));
+        assert!(cm.is_canonical_alias("MT"));
+
+        assert!(!cm.is_canonical_alias("chrUn_gl000211"));
+        assert!(!cm.is_canonical_alias("random_string"));
+    }
+
+    #[test]
+    fn test_is_autosomal_alias() {
+        let cm = get_manager();
+
+        assert!(cm.is_autosomal_alias("chr1"));
+        assert!(cm.is_autosomal_alias("22"));
+        assert!(cm.is_autosomal_alias("NC_000001.10"));
+
+        assert!(!cm.is_autosomal_alias("chrX"));
+        assert!(!cm.is_autosomal_alias("MT"));
+    }
+
+    #[test]
+    fn test_is_gonosomal_alias() {
+        let cm = get_manager();
+
+        assert!(cm.is_gonosomal_alias("chrX"));
+        assert!(cm.is_gonosomal_alias("Y"));
+        assert!(cm.is_gonosomal_alias("NC_000023.10")); // GRCh37 chrX
+
+        assert!(!cm.is_gonosomal_alias("chr1"));
+        assert!(!cm.is_gonosomal_alias("MT"));
+    }
+
+    #[test]
+    fn test_is_mitochondrial_alias() {
+        let cm = get_manager();
+
+        assert!(cm.is_mitochondrial_alias("chrM"));
+        assert!(cm.is_mitochondrial_alias("MT"));
+        assert!(cm.is_mitochondrial_alias("M"));
+        assert!(cm.is_mitochondrial_alias("NC_012920.1")); // GRCh37 MT
+
+        assert!(!cm.is_mitochondrial_alias("chr1"));
+        assert!(!cm.is_mitochondrial_alias("chrX"));
+    }
+
+    #[test]
+    fn test_get_chrom_no() {
+        let cm = get_manager();
+
+        assert_eq!(cm.get_chrom_no("chr1"), Some(1));
+        assert_eq!(cm.get_chrom_no("NC_000001.10"), Some(1));
+        assert_eq!(cm.get_chrom_no("chrX"), Some(23));
+        assert_eq!(cm.get_chrom_no("Y"), Some(24));
+        assert_eq!(cm.get_chrom_no("chrM"), Some(25));
+        assert_eq!(cm.get_chrom_no("MT"), Some(25));
+        assert_eq!(cm.get_chrom_no("unknown_contig"), None);
+    }
+
+    #[test]
+    fn test_get_primary_name() {
+        let cm = get_manager();
+
+        assert_eq!(cm.get_primary_name("chr1").map(|s| s.as_str()), Some("1"));
+        assert_eq!(
+            cm.get_primary_name("NC_000001.10").map(|s| s.as_str()),
+            Some("1")
+        );
+        assert_eq!(cm.get_primary_name("chrM").map(|s| s.as_str()), Some("MT"));
+        assert_eq!(cm.get_primary_name("M").map(|s| s.as_str()), Some("MT"));
+        assert_eq!(cm.get_primary_name("chrX").map(|s| s.as_str()), Some("X"));
+    }
+
+    #[test]
+    fn test_get_accession() {
+        let cm = get_manager();
+
+        assert_eq!(
+            cm.get_accession("chr1").map(|s| s.as_str()),
+            Some("NC_000001.10")
+        );
+        assert_eq!(
+            cm.get_accession("1").map(|s| s.as_str()),
+            Some("NC_000001.10")
+        );
+        assert_eq!(
+            cm.get_accession("chrM").map(|s| s.as_str()),
+            Some("NC_012920.1")
+        );
+    }
 }


### PR DESCRIPTION
- ~using annonars' canonicalize method ensures the keys for db access are the same~
- added additional checks to ensure that when frequencies / clinvar annotations are requested but somehow don't match, the user is informed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chromosome name normalization in frequency and ClinVar annotation lookups for improved accuracy.
  * Annotation initialization now fails with explicit error messages when required databases are missing or incompatible with the current assembly, instead of silently skipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->